### PR TITLE
UE4.26 Compatibility

### DIFF
--- a/UnrealPlugin/DazToUnreal/Source/DazToUnreal/DazToUnreal.Build.cs
+++ b/UnrealPlugin/DazToUnreal/Source/DazToUnreal/DazToUnreal.Build.cs
@@ -15,6 +15,7 @@ public class DazToUnreal : ModuleRules
 				"Core",
 				"Sockets",
 				"Networking",
+				"DeveloperSettings"
 				// ... add other public dependencies that you statically link with here ...
 			}
 			);


### PR DESCRIPTION
I was able to compile the plugin for unreal 4.26 with this simple fix.

Closes #4 